### PR TITLE
Fix warnings outputted by VSCode Lua extension

### DIFF
--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/alchemy.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/alchemy.lua
@@ -25,10 +25,7 @@ local this = {}
         with [int] must be an integer.
 ]]
 this.createBasicPotion = function(params)
-    local potion = tes3.getObject(params.id) or tes3alchemy.create({
-        id = params.id,
-        name = params.name,
-    })
+    local potion = tes3.createObject({ id = params.id, objectType = tes3.objectType.alchemy })
 
     potion.name = params.name
 
@@ -84,10 +81,7 @@ example = {
         with [int] must be an integer. @params.effects may only contain up to 8 entries.
 ]]
 this.createComplexPotion = function(params)
-    local potion = tes3.getObject(params.id) or tes3alchemy.create({
-        id = params.id,
-        name = params.name,
-    })
+	local potion = tes3.createObject({ id = params.id, objectType = tes3.objectType.alchemy })
 
     potion.name = params.name
 

--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/enchantments.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/enchantments.lua
@@ -25,8 +25,9 @@ local this = {}
         with [int] must be an integer.
 ]]
 this.createBasicEnchantment = function(params)
-    local enchantment = tes3.getObject(params.id) or tes3enchantment.create({
+    local enchantment = tes3.createObject({
         id = params.id,
+		objectType = tes3.objectType.enchantment,
         castType = tes3.enchantmentType.onUse,
         chargeCost = 1,
         maxCharge = 1
@@ -88,8 +89,9 @@ end
         with [int] must be an integer. @params.effects may only contain up to 8 entries.
 ]]
 this.createComplexEnchantment = function(params)
-    local enchantment = tes3.getObject(params.id) or tes3enchantment.create({
+    local enchantment = tes3.createObject({
         id = params.id,
+		objectType = tes3.objectType.enchantment,
         castType = tes3.enchantmentType.onUse,
         chargeCost = 1,
         maxCharge = 1

--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/grimoires.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/grimoires.lua
@@ -11,7 +11,7 @@ this.addGrimoiresToPlayer = function ()
     for _, grimoire in ipairs(grimoires) do
         if (tes3.getObject(grimoire.id)) then
             tes3.addItem({
-                reference = tes3.getPlayerRef(),
+                reference = tes3.player,
                 item = grimoire.id
             })
         else

--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/grimoires.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/grimoires.lua
@@ -11,7 +11,7 @@ this.addGrimoiresToPlayer = function ()
     for _, grimoire in ipairs(grimoires) do
         if (tes3.getObject(grimoire.id)) then
             tes3.addItem({
-                reference = tes3.getPlayerRef(), 
+                reference = tes3.getPlayerRef(),
                 item = grimoire.id
             })
         else
@@ -32,12 +32,12 @@ end
         }
     }
 ]]
-this.registerGrimoire = function(grimoire)	
+this.registerGrimoire = function(grimoire)
 	table.insert(grimoires, grimoire)
 end
 
 --[[
-    Description: Registers @grimoires as a collection of grimoires to be checked 
+    Description: Registers @grimoires as a collection of grimoires to be checked
         for when a book is opened.
 
     @grimoires: The grimoires to register. Must be in the following format:
@@ -64,8 +64,8 @@ this.registerGrimoires = function(grimoires)
 	end
 end
 
-local function FindGrimoire(bookId)   
-    for _, grimoire in ipairs(grimoires) do 
+local function FindGrimoire(bookId)
+    for _, grimoire in ipairs(grimoires) do
 		if (grimoire.id == bookId) then
 			return grimoire
 		end
@@ -78,9 +78,9 @@ local function tryLearningSpells(grimoire)
 	tes3.fadeOut({duration = 2})
 
     local hasMagicka = false
-    
+
     local learningCost = 0
-    for _, spellId in ipairs(grimoire.spellIds) do      
+    for _, spellId in ipairs(grimoire.spellIds) do
         learningCost = learningCost + tes3.getObject(spellId).magickaCost * 2
     end
 
@@ -95,9 +95,10 @@ local function tryLearningSpells(grimoire)
 			name = "magicka",
 			current = learningCost * -1
 		})
-        for _, spellId in ipairs(grimoire.spellIds) do      
-            mwscript.addSpell({reference = tes3.player, spell = spellId})
+        for _, spellId in ipairs(grimoire.spellIds) do
+            tes3.addSpell({reference = tes3.player, spell = spellId, updateGUI = false})
         end
+		tes3.updateMagicGUI({reference = tes3.player})
 		tes3.messageBox("As you study the tome and practice the spells described within, you feel new spells enter your mind.")
 	else
 		tes3.modStatistic({
@@ -114,13 +115,13 @@ end
 local function onBookGetText(e)
 	local grimoire = FindGrimoire(e.book.id)
 
-	if (grimoire == nil) then  
+	if (grimoire == nil) then
 		return
 	end
-    
+
     local newSpell = false
-    for _, spellId in ipairs(grimoire.spellIds) do      
-        if (common.hasSpell(tes3.player, spellId) == false) then		
+    for _, spellId in ipairs(grimoire.spellIds) do
+        if (common.hasSpell(tes3.player, spellId) == false) then
             newSpell = true
         end
     end
@@ -132,7 +133,7 @@ local function onBookGetText(e)
 end
 
 --[[
-	Description: Registers the grimoire event. On bookGetText, the collection of 
+	Description: Registers the grimoire event. On bookGetText, the collection of
 		registered grimoires will be iterated through. If the book belongs to the
 		collection of registered grimoires, the spells mapped to that grimoire will be
 		added to the player, if the player does not already have them.

--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/spells.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/spells.lua
@@ -132,7 +132,7 @@ end
         with [int] must be an integer. @params.effects may only contain up to 8 entries.
 ]]
 this.createComplexSpell = function(params)
-    local spell = tes3.getObject(params.id) or tes3spell.create(params.id, params.name)
+    local spell = tes3.createObject({ id = params.id, objectType = tes3.objectType.spell })
     tes3.setSourceless(spell)
 
     spell.name = params.name

--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/spells.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/spells.lua
@@ -73,7 +73,7 @@ end
         with [int] must be an integer.
 ]]
 this.createBasicSpell = function(params)
-    local spell = tes3.getObject(params.id) or tes3spell.create(params.id, params.name)
+    local spell = tes3.createObject({ id = params.id, objectType = tes3.objectType.spell })
     tes3.setSourceless(spell)
 
     spell.name = params.name

--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/tomes.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/tomes.lua
@@ -11,7 +11,7 @@ this.addTomesToPlayer = function()
 	for _, tome in ipairs(tomes) do
 		if (tes3.getObject(tome.id)) then
 			tes3.addItem({
-				reference = tes3.getPlayerRef(), 
+				reference = tes3.getPlayerRef(),
 				item = tome.id
 			})
         else
@@ -29,7 +29,7 @@ end
 		spellId = "exampleSpellId"
 	}
 ]]
-this.registerTome = function(tome)	
+this.registerTome = function(tome)
 	table.insert(tomes, tome)
 end
 
@@ -80,7 +80,7 @@ local function tryLearningSpell(tome)
 			name = "magicka",
 			current = learningCost * -1
 		})
-		mwscript.addSpell({reference = tes3.player, spell = tome.spellId})
+		tes3.addSpell({reference = tes3.player, spell = tome.spellId})
 		tes3.messageBox("As you study the tome and practice the spell described within, you feel a new spell enter your mind.")
 	else
 		tes3.modStatistic({
@@ -103,13 +103,13 @@ local function onBookGetText(e)
 
 	if (common.hasSpell(tes3.player, tome.spellId)) then
 		tes3.messageBox("You attempt to read the tome but can learn nothing more.")
-	else	
+	else
 		tryLearningSpell(tome)
 	end
 end
 
 --[[
-	Description: Registers the tome event. On bookGetText, the collection of 
+	Description: Registers the tome event. On bookGetText, the collection of
 		registered tomes will be iterated through. If the book belongs to the
 		collection of registered tomes, the spell mapped to that tome will be
 		added to the player, if the player does not already have it.

--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/tomes.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/classes/tomes.lua
@@ -11,7 +11,7 @@ this.addTomesToPlayer = function()
 	for _, tome in ipairs(tomes) do
 		if (tes3.getObject(tome.id)) then
 			tes3.addItem({
-				reference = tes3.getPlayerRef(),
+				reference = tes3.player,
 				item = tome.id
 			})
         else

--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/common.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/common.lua
@@ -46,8 +46,9 @@ end
 this.addTestSpellsToPlayer = function()
     for i = 1,#this.spells do
         local spell = this.spells[i]
-		mwscript.addSpell({reference = tes3.player, spell = spell})
+		tes3.addSpell({reference = tes3.player, spell = spell, updateGUI = false})
 	end
+	tes3.updateMagicGUI({reference = tes3.player})
 end
 
 this.addPotionToPotionsList = function(potion)

--- a/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/mcm.lua
+++ b/Magicka Expanded Package/00 - Framework/MWSE/lib/OperatorJack/MagickaExpanded/mcm.lua
@@ -43,12 +43,12 @@ local function createGeneralCategory(template)
 			if (tes3.player ~= nil) then
 				tes3.setStatistic({
 					reference = tes3.mobilePlayer,
-					attribute = 1,
+					attribute = tes3.attribute.intelligence,
 					current = 100
 				})
 				tes3.setStatistic({
 					reference = tes3.mobilePlayer,
-					attribute = 2,
+					attribute = tes3.attribute.willpower,
 					current = 100
 				})
 				--fuck me, fuck lua scripting and fuck this particular chunk of code
@@ -59,32 +59,32 @@ local function createGeneralCategory(template)
 				})
 				tes3.setStatistic({
 					reference = tes3.mobilePlayer,
-					skill = 11,
+					skill = tes3.skill.alteration,
 					current = 100
 				})
 				tes3.setStatistic({
 					reference = tes3.mobilePlayer,
-					skill = 10,
+					skill = tes3.skill.destruction,
 					current = 100
 				})
 				tes3.setStatistic({
 					reference = tes3.mobilePlayer,
-					skill = 15,
+					skill = tes3.skill.restoration,
 					current = 100
 				})
 				tes3.setStatistic({
 					reference = tes3.mobilePlayer,
-					skill = 13,
+					skill = tes3.skill.conjuration,
 					current = 100
 				})
 				tes3.setStatistic({
 					reference = tes3.mobilePlayer,
-					skill = 12,
+					skill = tes3.skill.illusion,
 					current = 100
 				})
 				tes3.setStatistic({
 					reference = tes3.mobilePlayer,
-					skill = 14,
+					skill = tes3.skill.mysticism,
 					current = 100
 				})
 				tes3.messageBox("[Magicka Expanded] Increased player's magic attributes and skills.")

--- a/Magicka Expanded Package/02 - Lore Friendly Pack/MWSE/mods/OperatorJack/MagickaExpanded-LoreFriendlyPack/effects/banishDaedraEffect.lua
+++ b/Magicka Expanded Package/02 - Lore Friendly Pack/MWSE/mods/OperatorJack/MagickaExpanded-LoreFriendlyPack/effects/banishDaedraEffect.lua
@@ -19,14 +19,14 @@ local function onBanishDaedraTick(e)
 	local magnitude = framework.functions.getCalculatedMagnitudeFromEffect(effect)
 
 	if (e.effectInstance.target.object.level <= magnitude) then
-		--@type tes3reference
+		---@type tes3reference
 		e.effectInstance.target:disable()
 
-		timer.delayOneFrame({
-			callback = function()
+		timer.delayOneFrame(
+			function()
 				e.effectInstance.target.deleted = true
 			end
-		})
+		)
 
 		tes3.messageBox("%s has been banished!", e.effectInstance.target.baseObject.name)
 	else

--- a/Magicka Expanded Package/02 - Lore Friendly Pack/MWSE/mods/OperatorJack/MagickaExpanded-LoreFriendlyPack/main.lua
+++ b/Magicka Expanded Package/02 - Lore Friendly Pack/MWSE/mods/OperatorJack/MagickaExpanded-LoreFriendlyPack/main.lua
@@ -24,65 +24,63 @@ local tomes = {
   {
     id = "OJ_ME_TomeBanishDaedra",
     spellId = spellIds.banishDaedra
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundGreaves",
     spellId = spellIds.boundGreaves
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundPauldrons",
     spellId = spellIds.boundPauldrons
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundClaymore",
     spellId = spellIds.boundClaymore
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundClub",
     spellId = spellIds.boundClub
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundDaiKatana",
     spellId = spellIds.boundDaiKatana
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundKatana",
     spellId = spellIds.boundKatana
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundShortsword",
     spellId = spellIds.boundShortSword
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundStaff",
     spellId = spellIds.boundStaff
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundTanto",
     spellId = spellIds.boundTanto
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundWakizashi",
     spellId = spellIds.boundWakizashi
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundWaraxe",
     spellId = spellIds.boundWarAxe
-  }, 
+  },
   {
     id = "OJ_ME_TomeBoundWarhammer",
     spellId = spellIds.boundWarhammer
-  }, 
+  },
 }
 
 local function addTomesToLists()
   local listId = "OJ_ME_LeveledList_Common"
+  local list = tes3.getObject(listId)
   for _, tome in pairs(tomes) do
-    mwscript.addToLevItem({
-      list = listId,
-      item = tome.id,
-      level = 1
-    })
+	local item = tes3.getObject(tome.id)
+	list:insert(item, 1)
   end
 end
 event.register("initialized", addTomesToLists)

--- a/Magicka Expanded Package/03 - Summoning Pack/MWSE/mods/OperatorJack/MagickaExpanded-SummoningPack/main.lua
+++ b/Magicka Expanded Package/03 - Summoning Pack/MWSE/mods/OperatorJack/MagickaExpanded-SummoningPack/main.lua
@@ -25,8 +25,8 @@ local spellIds = {
 }
 
 local grimoires = {
-  { 
-    id = "OJ_ME_GrimoireSummGoblin", 
+  {
+    id = "OJ_ME_GrimoireSummGoblin",
     spellIds = {
       spellIds.warDurzog,
       spellIds.goblinGrunt,
@@ -159,18 +159,14 @@ local tomes = {
 
 local function addTomesToLists()
   for _, tome in pairs(tomes) do
-    mwscript.addToLevItem({
-      list = tome.list,
-      item = tome.id,
-      level = 1
-    })
+	local item = tes3.getObject(tome.id)
+	local list = tes3.getObject(tome.list)
+	list:insert(item, 1)
   end
   for _, grimoire in pairs(grimoires) do
-    mwscript.addToLevItem({
-      list = grimoire.list,
-      item = grimoire.id,
-      level = 1
-    })
+	local item = tes3.getObject(grimoire.id)
+	local list = tes3.getObject(grimoire.list)
+	list:insert(item, 1)
   end
 end
 event.register("initialized", addTomesToLists)

--- a/Magicka Expanded Package/04 - Teleportation Pack/MWSE/mods/OperatorJack/MagickaExpanded-TeleportationPack/main.lua
+++ b/Magicka Expanded Package/04 - Teleportation Pack/MWSE/mods/OperatorJack/MagickaExpanded-TeleportationPack/main.lua
@@ -7,7 +7,7 @@ local spellIds = {
   balmora = "OJ_ME_TeleportToBalmora",
   ebonheart = "OJ_ME_TeleportToEbonheart",
   vivec = "OJ_ME_TeleportToVivec",
-  
+
   caldera = "OJ_ME_TeleportToCaldera",
   gnisis = "OJ_ME_TeleportToGnisis",
   maargan = "OJ_ME_TeleportToMaarGan",
@@ -85,11 +85,9 @@ local tomes = {
 
 local function addTomesToLists()
   for _, tome in pairs(tomes) do
-    mwscript.addToLevItem({
-      list = tome.list,
-      item = tome.id,
-      level = 1
-    })
+	local item = tes3.getObject(tome.id)
+	local list = tes3.getObject(tome.list)
+	list:insert(item, 1)
   end
 end
 event.register("initialized", addTomesToLists)
@@ -168,7 +166,7 @@ local function registerSpells()
     effect = tes3.effect.teleportToTelMora,
     range = tes3.effectRange.self
   })
-  
+
   framework.tomes.registerTomes(tomes)
 end
 

--- a/Magicka Expanded Package/05 - Tamriel Rebuilt Pack/MWSE/mods/OperatorJack/MagickaExpanded-TamrielRebuiltPack/main.lua
+++ b/Magicka Expanded Package/05 - Tamriel Rebuilt Pack/MWSE/mods/OperatorJack/MagickaExpanded-TamrielRebuiltPack/main.lua
@@ -286,22 +286,18 @@ local function addTomesToLists()
   end
 
   for _, tome in pairs(teleportTomes) do
-    mwscript.addToLevItem({
-      list = tome.list,
-      item = tome.id,
-      level = 1
-    })
+	local item = tes3.getObject(tome.id)
+	local list = tes3.getObject(tome.list)
+	list:insert(item, 1)
   end
   for _, tome in pairs(summonTomes) do
-    mwscript.addToLevItem({
-      list = tome.list,
-      item = tome.id,
-      level = 1
-    })
+	local item = tes3.getObject(tome.id)
+	local list = tes3.getObject(tome.list)
+	list:insert(item, 1)
   end
 end
 event.register("initialized", addTomesToLists)
- 
+
 
 local function registerSpells()
   if not tes3.isModActive("Tamriel_Data.esm") then
@@ -413,7 +409,7 @@ local function registerSpells()
     range = tes3.effectRange.self
   })
 
-  
+
   framework.spells.createBasicSpell({
     id = summonSpellIds.armorCenturion,
     name = "Summon Armor Centurion",
@@ -603,7 +599,7 @@ local function registerSpells()
     range = tes3.effectRange.self,
     duration = 30
   })
-  
+
   framework.tomes.registerTomes(teleportTomes)
   framework.tomes.registerTomes(summonTomes)
 end

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/entombEffect.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/entombEffect.lua
@@ -21,7 +21,6 @@ local function onEntombCollision(e)
             return
         end
 
-        ---@type tes3magicEffect
         local effectDuration = 2
         local distanceLimit = 250
         local position = e.collision.point:copy()
@@ -36,7 +35,8 @@ local function onEntombCollision(e)
         local actors = framework.functions.getActorsNearTargetPosition(caster.cell, position, distanceLimit)
         local spell = tes3.getObject("OJ_ME_EntombEffect")
 
-        mwscript.explodeSpell({
+		tes3.cast({
+            target = reference,
             reference = reference,
             spell = spell
         })
@@ -81,7 +81,7 @@ local function onEntombCollision(e)
         {
             duration = effectDuration,
             callback = function()
-                --@type tes3reference
+                ---@type tes3reference
                 reference:disable()
 
                 timer.delayOneFrame({

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/entombEffect.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/entombEffect.lua
@@ -84,11 +84,11 @@ local function onEntombCollision(e)
                 ---@type tes3reference
                 reference:disable()
 
-                timer.delayOneFrame({
-                    callback = function()
+                timer.delayOneFrame(
+                    function()
                         reference.deleted = true
                     end
-                })
+                )
             end
         })
 	end

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/entombEffect.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/entombEffect.lua
@@ -70,10 +70,7 @@ local function onEntombCollision(e)
                     })
                 end
 
-                mwscript.startCombat({
-                    reference = actor,
-                    target = caster
-                })
+                actor.mobile:startCombat(caster.mobile)
             end
         end
 

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/iceBarrageEffect.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/iceBarrageEffect.lua
@@ -20,7 +20,6 @@ local function onIceBarrageCollision(e)
             return
         end
 
-        ---@type tes3magicEffect
         local effectDuration = 2
         local distanceLimit = 250
         local position = e.collision.point:copy()
@@ -35,7 +34,8 @@ local function onIceBarrageCollision(e)
         local actors = framework.functions.getActorsNearTargetPosition(caster.cell, position, distanceLimit)
         local spell = tes3.getObject("OJ_ME_IceBarrageEffect")
 
-        mwscript.explodeSpell({
+		tes3.cast({
+            target = reference,
             reference = reference,
             spell = spell
         })

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/iceBarrageEffect.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/iceBarrageEffect.lua
@@ -83,11 +83,11 @@ local function onIceBarrageCollision(e)
                 --@type tes3reference
                 reference:disable()
 
-                timer.delayOneFrame({
-                    callback = function()
+                timer.delayOneFrame(
+                    function()
                         reference.deleted = true
                     end
-                })
+                )
             end
         })
 	end

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/iceBarrageEffect.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/iceBarrageEffect.lua
@@ -69,10 +69,7 @@ local function onIceBarrageCollision(e)
                     })
                 end
 
-                mwscript.startCombat({
-                    reference = actor,
-                    target = caster
-                })
+                actor.mobile:startCombat(caster.mobile)
             end
         end
 

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/thunderboltEffect.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/thunderboltEffect.lua
@@ -83,11 +83,11 @@ local function onThunderboltCollision(e)
                 --@type tes3reference
                 reference:disable()
 
-                timer.delayOneFrame({
-                    callback = function()
+                timer.delayOneFrame(
+                    function()
                         reference.deleted = true
                     end
-                })
+                )
             end
         })
 	end

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/thunderboltEffect.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/thunderboltEffect.lua
@@ -69,10 +69,7 @@ local function onThunderboltCollision(e)
                     })
                 end
 
-                mwscript.startCombat({
-                    reference = actor,
-                    target = caster
-                })
+                actor.mobile:startCombat(caster.mobile)
             end
         end
 

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/thunderboltEffect.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/effects/thunderboltEffect.lua
@@ -20,7 +20,6 @@ local function onThunderboltCollision(e)
             return
         end
 
-        ---@type tes3magicEffect
         local effectDuration = 2
         local distanceLimit = 250
         local position = e.collision.point:copy()
@@ -35,7 +34,8 @@ local function onThunderboltCollision(e)
         local actors = framework.functions.getActorsNearTargetPosition(caster.cell, position, distanceLimit)
         local spell = tes3.getObject("OJ_ME_ThunderBoltEffect")
 
-        mwscript.explodeSpell({
+		tes3.cast({
+            target = reference,
             reference = reference,
             spell = spell
         })

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/main.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/main.lua
@@ -250,7 +250,7 @@ local function registerSpells()
     effect = tes3.effect.weatherRain,
     range = tes3.effectRange.self
   })
-  
+
   framework.tomes.registerTomes(weatherTomes)
 end
 
@@ -278,10 +278,10 @@ local function onLoaded()
       count = 1
     })
 
-    mwscript.addSpell({
-      reference = "fevyn ralen",
-      spell = weatherSpellIds.weatherOvercast
-    })
+	tes3.addSpell({
+		reference = "fevyn ralen",
+		spell = weatherSpellIds.weatherOvercast
+	})
 
     tes3.addItem({
       reference = "lloros sarano",

--- a/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/main.lua
+++ b/Magicka Expanded Package/06 - Weather Magic Pack/MWSE/mods/OperatorJack/MagickaExpanded-WeatherMagicPack/main.lua
@@ -93,11 +93,9 @@ local weatherTomes = {
 
 local function addTomesToLists()
   for _, tome in pairs(weatherTomes) do
-    mwscript.addToLevItem({
-      list = tome.list,
-      item = tome.id,
-      level = 1
-    })
+	local item = tes3.getObject(tome.id)
+	local list = tes3.getObject(tome.list)
+	list:insert(item, 1)
   end
 end
 event.register("initialized", addTomesToLists)

--- a/Magicka Expanded Package/07 - Cortex Pack/MWSE/mods/OperatorJack/MagickaExpanded-CortexPack/effects/cloneEffect.lua
+++ b/Magicka Expanded Package/07 - Cortex Pack/MWSE/mods/OperatorJack/MagickaExpanded-CortexPack/effects/cloneEffect.lua
@@ -11,7 +11,7 @@ local clonePotionId = "OJ_ME_ClonePotion"
 local clonePotionName = "Clone"
 
 local id = "A shady smuggler"
-local function onCloneSourceTick(e)	
+local function onCloneSourceTick(e)
     e:triggerSummon(id)
 end
 
@@ -46,7 +46,7 @@ local function onCloneTick(e)
         id = e.effectInstance.target.object.id
         local effect = framework.functions.getEffectFromEffectOnEffectEvent(e, tes3.effect.clone)
         local magnitude = framework.functions.getCalculatedMagnitudeFromEffect(effect)
-    
+
         if (e.effectInstance.target.object.level <= magnitude) then
             local duration = effect.duration
             local potion = framework.alchemy.createBasicPotion({
@@ -55,12 +55,11 @@ local function onCloneTick(e)
                 effect = tes3.effect.cloneSource,
                 duration = duration
             })
-        
-            mwscript.equip({
-                reference = e.sourceInstance.caster,
+
+            e.sourceInstance.caster.mobile:equip({
                 item = potion
             })
-        
+
         else
             tes3.messageBox("%s was too powerful to be cloned!", e.effectInstance.target.baseObject.name)
         end

--- a/Magicka Expanded Package/07 - Cortex Pack/MWSE/mods/OperatorJack/MagickaExpanded-CortexPack/effects/darknessEffect.lua
+++ b/Magicka Expanded Package/07 - Cortex Pack/MWSE/mods/OperatorJack/MagickaExpanded-CortexPack/effects/darknessEffect.lua
@@ -19,11 +19,11 @@ local function onDarknessCollision(e)
         })
 
         -- Add a mechanic to the darkness mesh.
-        timer.start({ 
+        timer.start({
             duration = 1,
             callback = function()
                 local actors = framework.functions.getActorsNearTargetPosition(caster.cell, mistPosition, distanceLimit)
-        
+
                 -- For any actors near the darkness, remove the light effect if it exists.
                 for _, actor in pairs(actors) do
                     tes3.removeEffects({
@@ -31,8 +31,8 @@ local function onDarknessCollision(e)
                         effect = tes3.effect.light
                     })
                 end
-            end, 
-            iterations = (effectDuration - 1) 
+            end,
+            iterations = (effectDuration - 1)
         })
 
         timer.start(
@@ -42,11 +42,11 @@ local function onDarknessCollision(e)
                 --@type tes3reference
                 mistReference:disable()
 
-                timer.delayOneFrame({
-                    callback = function()
+                timer.delayOneFrame(
+                    function()
                         mistReference.deleted = true
                     end
-                })
+                )
             end
         })
 	end

--- a/Magicka Expanded Package/07 - Cortex Pack/MWSE/mods/OperatorJack/MagickaExpanded-CortexPack/effects/mindRipEffect.lua
+++ b/Magicka Expanded Package/07 - Cortex Pack/MWSE/mods/OperatorJack/MagickaExpanded-CortexPack/effects/mindRipEffect.lua
@@ -53,7 +53,7 @@ local function showCheckPassedTooltip(e)
         if (effect == nil) then
             return
         end
-        
+
 
         local effectContainer = effectsContainer:createBlock()
         effectContainer.flowDirection = "left_to_right"
@@ -100,10 +100,10 @@ local function onSpellSelected(e)
             current = newMagicka * -1
         })
 
-        mwscript.addSpell({
-            reference = tes3.player,
-            spell = spell
-        })
+		tes3.addSpell({
+			reference = tes3.player,
+			spell = spell
+		})
 
         tes3.messageBox("You successfully learn the spell.")
     else
@@ -115,7 +115,7 @@ local function onSpellSelected(e)
 
         tes3.messageBox("You fail to learn the spell.")
     end
-    
+
     tes3ui.forcePlayerInventoryUpdate()
     tes3ui.leaveMenuMode()
     menu:destroy()
@@ -162,14 +162,14 @@ local function showUi(reference)
         id = GUI_ID.listPane
     })
     for _, spell in pairs(spells) do
-        local parent = listPane:createBlock()     
+        local parent = listPane:createBlock()
         parent.flowDirection = "left_to_right"
         parent.childAlignX = 0
         parent.autoHeight = true
         parent.borderAllSides = 3
         parent.widthProportional = 1.0
         parent:setPropertyObject("OJ_ME_MR:Spell", spell)
- 
+
         if (spell.magickaCost / tes3.mobilePlayer.intelligence.current > 2.0) then
             local label = parent:createLabel({
                 text = string.format("%s", spell.name)
@@ -183,7 +183,7 @@ local function showUi(reference)
                 text = string.format("%s - %spts", spell.name, spell.magickaCost)
             })
             label.wrapText = true
-    
+
             parent:register("mouseClick", onSpellSelected)
             parent:register("help", showCheckPassedTooltip)
         end

--- a/Magicka Expanded Package/07 - Cortex Pack/MWSE/mods/OperatorJack/MagickaExpanded-CortexPack/main.lua
+++ b/Magicka Expanded Package/07 - Cortex Pack/MWSE/mods/OperatorJack/MagickaExpanded-CortexPack/main.lua
@@ -30,7 +30,7 @@ local tomes = {
     id = "OJ_ME_TomeDarkness",
     spellId = spellIds.veilOfDarkness,
     list = "OJ_ME_LeveledList_Rare"
-  }, 
+  },
   {
     id = "OJ_ME_TomeClone",
     spellId = spellIds.clone,
@@ -65,11 +65,9 @@ local tomes = {
 
 local function addTomesToLists()
   for _, tome in pairs(tomes) do
-    mwscript.addToLevItem({
-      list = tome.list,
-      item = tome.id,
-      level = 1
-    })
+	local item = tes3.getObject(tome.id)
+	local list = tes3.getObject(tome.list)
+	list:insert(item, 1)
   end
 end
 event.register("initialized", addTomesToLists)
@@ -137,7 +135,7 @@ local function registerSpells()
     range = tes3.effectRange.self,
     duration = 30
   })
-  
+
   framework.tomes.registerTomes(tomes)
 end
 


### PR DESCRIPTION
Here I propose a fix for most of the warnings:
1. Use `tes3.addSpell` instead of `mwscript.addSpell`.
2. Use `tes3.cast` instead of `mwscript.explodeSpell`. Passing both the same object to the `target` and `reference` arguments of `tes3.cast` will [produce the same effect](https://mwse.github.io/MWSE/apis/tes3/#tes3cast).
3. Use `tes3.player` instead of `tes3.getPlayerRef`.
4. Use `tes3.createObject` instead of e.g. `tes3.getObject() or tes3enchantment.create()` construction. The tes3enhantment.create, and others are now deprecated, and `tes3.createObject` is the new way to do it. In addition, it will, by default [return the existing object if it exists](https://mwse.github.io/MWSE/apis/tes3/#tes3createobject), rendering the first call to `tes3.getObject` unneeded.
5. Use `tes3mobileActor:equip` instead of `mwscript.equip`
6. Use `tes3mobileActor:startCombat` instead of `mwscript.startCombat`
7. Use `tes3leveledItem:insert` instead of `mwscript.addToLvlItem`
8. Fixed calls to the `timer.delayOneFrame`. [Here ](https://github.com/MWSE/morrowind-nexus-lua-dump/search?q=timer.delayOneFrame)are examples of how other people used the function.

In addition, I replaced the magic numbers in mcm.lua with the appropriate `tes3.skill` and `tes3.attribute` constants.